### PR TITLE
Obtain relevant Facebook insights

### DIFF
--- a/facebook-general.R
+++ b/facebook-general.R
@@ -4,17 +4,47 @@ library(Rfacebook)
 library(dplyr)
 library(stringr)
 
-# Insights on NESREA Page
-insights <- getInsights(object_id = NESREA_page_id, token = NESREA_token,
-            metric = "page_impressions", version = API_version)
+source("fb_authentication.R")
 
-core_insights <- select(insights, value:end_time)
-core_insights$end_time <- substr(core_insights$end_time, start = 1,
-         stop = regexpr("T", insights$end_time) - 1)
-core_insights
+# Insights on NESREA Page
+# Define a function to simplify our use of Rfacebook::getInsights()
+chooseInsight <- function(type = c("page_fan_adds", "page_fan_removes",
+                              "page_views_login", "page_views_logout",
+                              "page_views", "page_story_adds",
+                              "page_impressions", "page_posts_imporessions",
+                              "page_consumptions", "post_consumptions_by_type",
+                              "page_fans_country")) {
+  result <- getInsights(object_id = NESREA_page_id,
+                        token = NESREA_token,
+                        metric = type,
+                        version = API_version)
+  result <- select(result, value:end_time)
+  result$end_time <- substr(result$end_time,
+                            start = 1,
+                            stop = regexpr("T", result$end_time) - 1)
+  result 
+}
+
+newFans <- chooseInsight("page_fan_adds")
+fansLeft <- chooseInsight("page_fan_removes")
+pageViewsLogin <- chooseInsight("page_views_login")
+pageViews <- chooseInsight("page_views")
+newStories <- chooseInsight("page_story_adds")
+pageImpressions <- chooseInsight("page_impressions")
+postImpressions <- chooseInsight("page_posts_impressions")
+pageConsumptions <- chooseInsight("page_consumptions")
+
+# build a single dataframe from these objects
+allInsights <- data.frame(newFans[, 1], fansLeft[, 1], pageViewsLogin[, 1],
+                          pageViews[, 1], newStories[, 1], pageImpressions[, 1],
+                          postImpressions[, 1], pageConsumptions[, 1],
+                          endtime = pageConsumptions[, 2])
+colnames(allInsights) <- gsub("[^[:alpha:]]", "", colnames(allInsights))
+
 
 # PUblic posts
-page_posts <- getPage(page = "nesreanigeria", token = NESREA_token, feed = TRUE) %>%
+page_posts <- getPage(page = "nesreanigeria",
+                      token = NESREA_token, feed = TRUE) %>%
   select(., c(message:type, likes_count:shares_count))
 colnames(page_posts) <- gsub("_count$|_time$", "", colnames(page_posts))
 page_posts$message <- page_posts$message %>%


### PR DESCRIPTION
I wrote a simple function out of the existing code (line 10 - 26). This function will allow us to run a number of options for downloading insights from Facebook as seen in lines 28 - 35. This greatly simlifies the process.

In line 7 I added code that sources the authentication details that allow access to the Facebook API. Members of the team should ask for this file and I will send it via email. Add it to the NESREA_social main repo directory so that the file can find it and it will also get added to .gitignore and will not be added to your own commits.